### PR TITLE
(#130) Fix selectors for Related Resources test.

### DIFF
--- a/src/main/java/gov/cancer/pageobject/crosscutting/RelatedResourcesPage.java
+++ b/src/main/java/gov/cancer/pageobject/crosscutting/RelatedResourcesPage.java
@@ -3,9 +3,9 @@ package gov.cancer.pageobject.crosscutting;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import gov.cancer.framework.ElementHelper;
 import gov.cancer.pageobject.PageObjectBase;
 import gov.cancer.pageobject.helper.RelatedResource;
 
@@ -16,21 +16,19 @@ public class RelatedResourcesPage extends PageObjectBase {
    * whether it is null before using.
    */
   WebElement relatedResourcesSection;
+  final static String RELATED_LINK_SELECTOR = ":scope ul li";
 
   /**
    * Constructor
    *
-   * @param path server-relative path of the page to load.
+   * @param path
+   *          server-relative path of the page to load.
    */
   public RelatedResourcesPage(String path) {
     super(path);
 
     // Get the actual section, if it's present.
-    List<WebElement> findList = getBrowser().findElements(By.cssSelector("#nvcgRelatedResourcesArea"));
-    if (findList.size() > 0)
-      relatedResourcesSection = findList.get(0);
-    else
-      relatedResourcesSection = null;
+    relatedResourcesSection = ElementHelper.findElement(getBrowser(), "#nvcgRelatedResourcesArea");
 
   }
 
@@ -50,8 +48,7 @@ public class RelatedResourcesPage extends PageObjectBase {
 
     List<RelatedResource> links = new ArrayList<RelatedResource>();
 
-    List<WebElement> rawLinks = relatedResourcesSection.findElements(By.cssSelector("ul li"));
-
+    List<WebElement> rawLinks = ElementHelper.findElements(relatedResourcesSection, RELATED_LINK_SELECTOR);
     for (WebElement link : rawLinks) {
       links.add(new RelatedResource(link));
     }

--- a/src/main/java/gov/cancer/pageobject/helper/RelatedResource.java
+++ b/src/main/java/gov/cancer/pageobject/helper/RelatedResource.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import gov.cancer.framework.Configuration;
+import gov.cancer.framework.ElementHelper;
 import gov.cancer.framework.LinkHelper;
 
 /*
@@ -21,10 +22,13 @@ public class RelatedResource {
   // Getting configuration file to access domain values
   Configuration config;
 
+  static final String LINK_SELECTOR = ":scope a:nth-child(1)";
+  static final String EXTLINK_SELECTOR = ":scope a:nth-child(2)";
+
   // Related Resources links
   public RelatedResource(WebElement element) {
     this.element = element;
-    resourceLink = element.findElement(By.cssSelector("a:nth-child(1)"));
+    resourceLink = ElementHelper.findElement(element, LINK_SELECTOR);
     config = new Configuration();
   }
 
@@ -33,7 +37,7 @@ public class RelatedResource {
    */
   public boolean hasExitDisclaimer() {
     // externalLink with icon-exit-notification
-    WebElement externalLink = element.findElement(By.cssSelector("a:nth-child(2)"));
+    WebElement externalLink = ElementHelper.findElement(element, EXTLINK_SELECTOR);
     return externalLink.isDisplayed() && externalLink.getAttribute("class").equals("icon-exit-notification");
   }
 
@@ -48,8 +52,8 @@ public class RelatedResource {
   }
 
   /*
-   * if element is null return false; else trim the element text and if its empty
-   * return false (ex: string between a tag)
+   * if element is null return false; else trim the element text and if its
+   * empty return false (ex: string between a tag)
    */
   public boolean isLinkTextBlank() {
     if (resourceLink != null)
@@ -68,8 +72,8 @@ public class RelatedResource {
   }
 
   /*
-   * Verifying Exit Disclaimer styling for Related Resource link that doesn't end
-   * with .gov,
+   * Verifying Exit Disclaimer styling for Related Resource link that doesn't
+   * end with .gov,
    */
   public boolean isExternal() {
     URL url = null;


### PR DESCRIPTION
Updated selectors and utilized methods of ElementHelper class to fix the errors in ExitDisclaimer tests for Related Resources tests

Please review and approve.
Closes #130 